### PR TITLE
Java 1.6 support for okhttp-urlconnection + maven compiler plugin + remo...

### DIFF
--- a/okhttp-urlconnection/pom.xml
+++ b/okhttp-urlconnection/pom.xml
@@ -44,6 +44,17 @@
           </links>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.2</version>
+        <configuration>
+          <source>1.6</source>
+          <target>1.6</target>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 </project>
+
+

--- a/okhttp-urlconnection/src/main/java/com/squareup/okhttp/OkUrlFactory.java
+++ b/okhttp-urlconnection/src/main/java/com/squareup/okhttp/OkUrlFactory.java
@@ -68,7 +68,7 @@ public final class OkUrlFactory implements URLStreamHandlerFactory, Cloneable {
    *   URL.setURLStreamHandlerFactory(new OkUrlFactory(okHttpClient));
    * }</pre>
    */
-  @Override public URLStreamHandler createURLStreamHandler(final String protocol) {
+  public URLStreamHandler createURLStreamHandler(final String protocol) {
     if (!protocol.equals("http") && !protocol.equals("https")) return null;
 
     return new URLStreamHandler() {

--- a/okhttp-urlconnection/src/main/java/com/squareup/okhttp/internal/huc/HttpURLConnectionImpl.java
+++ b/okhttp-urlconnection/src/main/java/com/squareup/okhttp/internal/huc/HttpURLConnectionImpl.java
@@ -34,6 +34,7 @@ import com.squareup.okhttp.internal.http.HttpMethod;
 import com.squareup.okhttp.internal.http.OkHeaders;
 import com.squareup.okhttp.internal.http.RetryableSink;
 import com.squareup.okhttp.internal.http.StatusLine;
+
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
@@ -55,6 +56,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
+
 import okio.BufferedSink;
 import okio.Sink;
 
@@ -71,7 +73,7 @@ import okio.Sink;
  * header fields, request method, etc.) are immutable.
  */
 public class HttpURLConnectionImpl extends HttpURLConnection {
-  private static final Set<String> METHODS = new LinkedHashSet<>(
+  private static final Set<String> METHODS = new LinkedHashSet<String>(
       Arrays.asList("OPTIONS", "GET", "HEAD", "POST", "PUT", "DELETE", "TRACE", "PATCH"));
 
   final OkHttpClient client;
@@ -537,7 +539,7 @@ public class HttpURLConnectionImpl extends HttpURLConnection {
    * defined in {@link Protocol OkHttp's protocol enumeration}.
    */
   private void setProtocols(String protocolsString, boolean append) {
-    List<Protocol> protocolsList = new ArrayList<>();
+    List<Protocol> protocolsList = new ArrayList<Protocol>();
     if (append) {
       protocolsList.addAll(client.getProtocols());
     }
@@ -562,7 +564,7 @@ public class HttpURLConnectionImpl extends HttpURLConnection {
     setFixedLengthStreamingMode((long) contentLength);
   }
 
-  @Override public void setFixedLengthStreamingMode(long contentLength) {
+  public void setFixedLengthStreamingMode(long contentLength) {
     if (super.connected) throw new IllegalStateException("Already connected");
     if (chunkLength > 0) throw new IllegalStateException("Already in chunked mode");
     if (contentLength < 0) throw new IllegalArgumentException("contentLength < 0");

--- a/okhttp/pom.xml
+++ b/okhttp/pom.xml
@@ -43,6 +43,18 @@
           </links>
         </configuration>
       </plugin>
-    </plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.2</version>
+        <configuration>
+          <source>1.6</source>
+          <target>1.6</target>
+        </configuration>
+      </plugin>
+    
+      </plugins>
+    
   </build>
+
 </project>

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/Platform.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/Platform.java
@@ -16,7 +16,7 @@
  */
 package com.squareup.okhttp.internal;
 
-import android.annotation.SuppressLint;
+
 import com.squareup.okhttp.Protocol;
 import java.io.IOException;
 import java.lang.reflect.InvocationHandler;
@@ -205,7 +205,6 @@ public class Platform {
       SET_ALPN_PROTOCOLS.invokeWithoutCheckedException(sslSocket, parameters);
     }
 
-	@SuppressLint("NewApi")
 	@Override public String getSelectedProtocol(SSLSocket socket) {
       boolean alpnSupported = GET_ALPN_SELECTED_PROTOCOL.isSupported(socket);
       if (!alpnSupported) {

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
     <module>okhttp-android-support</module>
     <module>okcurl</module>
     <module>mockwebserver</module>
-    <module>samples</module>
+    
     <module>benchmarks</module>
   </modules>
 
@@ -34,7 +34,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
     <!-- Compilation -->
-    <java.version>1.7</java.version>
+    <java.version>1.6</java.version>
     <okio.version>1.2.0</okio.version>
     <!-- ALPN library targeted to Java 7 -->
     <alpn.jdk7.version>7.1.2.v20141202</alpn.jdk7.version>


### PR DESCRIPTION
i) Added suport for java 1.6 in the sub-module okhttp-urlconnection + other changes to support java 1.6
Example: 
HttpURLConnectionImpl.java: List<Protocol> protocolsList = new ArrayList<>();

ii) Added maven compiler plugin
